### PR TITLE
Fix cpptest fails

### DIFF
--- a/.devcontainer/src/.bashrc
+++ b/.devcontainer/src/.bashrc
@@ -1,5 +1,5 @@
 # Test
-alias cpptest='g++ main.cpp && oj t -d ./tests'                  # C++
+alias cpptest='g++ main.cpp && oj t -d ./tests'                 # C++
 alias pypytest='oj t -c "pypy3 main.py" -d ./tests'             # PyPy3
 alias py3test='oj t -c "python3 main.py" -d ./tests'            # CPython
 

--- a/.devcontainer/src/.bashrc
+++ b/.devcontainer/src/.bashrc
@@ -1,5 +1,5 @@
 # Test
-alias cpptest='g++ main.cpp | oj t -d ./tests'                  # C++
+alias cpptest='g++ main.cpp && oj t -d ./tests'                  # C++
 alias pypytest='oj t -c "pypy3 main.py" -d ./tests'             # PyPy3
 alias py3test='oj t -c "python3 main.py" -d ./tests'            # CPython
 


### PR DESCRIPTION
## 実施内容
* `cpptest`を実行する際、まれに`g++ main.cpp`の部分の終了を待たずに`oj test`が実行される事象の修正を行いました。
* 具体的には、`[ERROR] No such file or directory: ['./a.out']`というエラーへの対処です。

## 確認済み項目
* 今までの操作で`cpptest`が正常に終了すること